### PR TITLE
Adding the wrap flag to avoid horizontal scrolling

### DIFF
--- a/src/MicroEd/MDMicroEdPresenter.class.st
+++ b/src/MicroEd/MDMicroEdPresenter.class.st
@@ -152,6 +152,7 @@ MDMicroEdPresenter >> initializePresentersWithText: anInputText [
 		morph: (RubScrolledTextMorph new 
 			hResizing: #spaceFill; 
 			vResizing: #spaceFill;
+			wrapFlag: true;
 			in: [ :this | this textArea readOnly: true ];
 			yourself);
 		yourself.


### PR DESCRIPTION
I use MicroEd (edition and visualization) in a tool to perform user experiments.
I added a `wrapFlag` to wrap the text in the output text viewer for comfort: it avoid long sentences to go beyond the visible part of the window, and wraps it in the next line instead.

This is important because all developers (or users in my case) do not have the same large screens as us.

Thanks for considering it :)

You can see an example in this screenshot:

![Screenshot 2021-05-28 at 11 55 03](https://user-images.githubusercontent.com/26929529/119966393-8d8be300-bfab-11eb-9eeb-1a6ff93c3650.png)
