### PR TITLE
Replace the extension 'mic' by 'md'

### DIFF
--- a/src/MicroEd-Spec-Tests/MDEditorFilePresenterTest.class.st
+++ b/src/MicroEd-Spec-Tests/MDEditorFilePresenterTest.class.st
@@ -99,7 +99,7 @@ MDEditorFilePresenterTest >> testSaveWithExtension [
 	presenter mdFile: mdFile.
 	presenter saveFile.
 
-	self assert: mdFile extension equals: 'mic'.
+	self assert: mdFile extension equals: 'md'.
 	self assert: mdFile contents equals: text.
 	
 ]

--- a/src/MicroEd/MDMicroDownSyntax.class.st
+++ b/src/MicroEd/MDMicroDownSyntax.class.st
@@ -61,7 +61,7 @@ A codeblock:
 { #category : 'accessing' }
 MDMicroDownSyntax >> extension [
 
-	^ 'mic'
+	^ 'md'
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
I replace the extension of the MDFile's fileReference  : '.mic' to '.md' . 