### PR TITLE
correct the method MDFile>>save: withExtension:

### DIFF
--- a/src/MicroEd-Spec-Tests/MDEditorFilePresenterTest.class.st
+++ b/src/MicroEd-Spec-Tests/MDEditorFilePresenterTest.class.st
@@ -27,7 +27,7 @@ MDEditorFilePresenterTest >> setUp [
 	presenter := MDEditorPresenter new.
 	window := presenter open.
 	text := 'This is just a test'.
-	fileReference := memoryFS / 'aFileReference.txt'.
+	fileReference := memoryFS / 'aFileReference.md'.
 	fileReference writeStreamDo: [
 		                 :stream | stream nextPutAll: text ].
 
@@ -96,6 +96,7 @@ MDEditorFilePresenterTest >> testSaveWithExtension [
 	| text textPresenter |
 	text := 'This is just a test'.
 	textPresenter := self mockTextObject: text.
+	presenter textInputText: text. 
 	presenter mdFile: mdFile.
 	presenter saveFile.
 

--- a/src/MicroEd-Spec/MDEditorPresenter.class.st
+++ b/src/MicroEd-Spec/MDEditorPresenter.class.st
@@ -225,7 +225,7 @@ MDEditorPresenter >> startNewFile [
 
 	self cleanInput.
 	mdFile := MDFile new.
-	self updateTitle
+	self window ifNotNil: [ self updateTitle ] 
 ]
 
 { #category : 'accessing' }

--- a/src/MicroEd-Spec/MDEditorPresenter.class.st
+++ b/src/MicroEd-Spec/MDEditorPresenter.class.st
@@ -161,7 +161,7 @@ MDEditorPresenter >> mdFile [
 MDEditorPresenter >> mdFile: aMDFile [
 
 	mdFile := aMDFile.
-	textInput text: mdFile contents    
+	"textInput text: mdFile contents"    
 ]
 
 { #category : 'utilities' }

--- a/src/MicroEd-Spec/MDEditorPresenter.class.st
+++ b/src/MicroEd-Spec/MDEditorPresenter.class.st
@@ -160,8 +160,7 @@ MDEditorPresenter >> mdFile [
 { #category : 'accessing' }
 MDEditorPresenter >> mdFile: aMDFile [
 
-	mdFile := aMDFile.
-	"textInput text: mdFile contents"    
+	mdFile := aMDFile.   
 ]
 
 { #category : 'utilities' }
@@ -208,7 +207,7 @@ MDEditorPresenter >> saveFile [
 	self mdFile: (self mdFile
 			 save: textInput text asString 
 			 withExtension: syntaxState extension).
-	self updateTitle.
+self window ifNotNil: [self updateTitle].
 
 ]
 

--- a/src/MicroEd-Spec/MDEditorPresenter.class.st
+++ b/src/MicroEd-Spec/MDEditorPresenter.class.st
@@ -52,7 +52,7 @@ MDEditorPresenter >> cleanOutput [
 	textOutput text: ''
 ]
 
-{ #category : 'specs' }
+{ #category : 'layout' }
 MDEditorPresenter >> defaultLayout [
 
 	 ^ SpBoxLayout newTopToBottom

--- a/src/MicroEd-Tests/MDFileTest.class.st
+++ b/src/MicroEd-Tests/MDFileTest.class.st
@@ -19,8 +19,8 @@ MDFileTest >> setUp [
 	memoryFS := FileSystem memory.
 	toDelete := OrderedCollection new.
 	fileWithoutFileReference := MDFile new.
-	fileExample := memoryFS / 'example.txt'.
-	fileReferenceWithName := (memoryFS / 'anotherFile.txt')
+	fileExample := memoryFS / 'example.md'.
+	fileReferenceWithName := (memoryFS / 'anotherFile.md')
 		                         ensureCreateFile.
 	toDelete add: fileExample. 
 	fileExample writeStreamDo: [ :stream |
@@ -58,11 +58,11 @@ MDFileTest >> testMDFileExistingFileWithName [
 	
 	| file fileReferenceWithoutName |
 	
-	fileReferenceWithoutName := (memoryFS / 'name.txt') ensureCreateFile.
+	fileReferenceWithoutName := (memoryFS / 'name.md') ensureCreateFile.
 	toDelete add: fileReferenceWithoutName. 
 	file := MDFile new.
 	file initializeWithFileReference: fileReferenceWithoutName.
-	self assert: (file basename endsWith: 'name.txt'). 
+	self assert: (file basename endsWith: 'name.md'). 
 
 	
 ]
@@ -72,7 +72,7 @@ MDFileTest >> testMDFileExistingFileWithoutName [
 
 	| file fileReferenceWithoutName |
  	
-	fileReferenceWithoutName := (memoryFS / '.txt') ensureCreateFile.
+	fileReferenceWithoutName := (memoryFS / '.md') ensureCreateFile.
 	toDelete add: fileReferenceWithoutName. 
 	file := MDFile new.
 	file initializeWithFileReference: fileReferenceWithoutName.
@@ -86,5 +86,6 @@ MDFileTest >> testMDFileHasFileReferenceWithFormatISO [
 	| file date |
 	file := MDFile newFromFileReference: fileReferenceWithName. 
 	date := DateAndTime now asDate yyyymmdd.
-	self assert: (file basename includesSubstring: date)
+	self assert: (file basename includesSubstring: date).
+	self deny: (fileReferenceWithName exists )
 ]

--- a/src/MicroEd-Tests/MDMicroDownSyntaxTest.class.st
+++ b/src/MicroEd-Tests/MDMicroDownSyntaxTest.class.st
@@ -12,7 +12,7 @@ Class {
 MDMicroDownSyntaxTest >> testGotExtensionWhenIsNotSpecify [
 
 	syntax := MDMicroDownSyntax new.
-	self assert: syntax extension equals: 'mic'
+	self assert: syntax extension equals: 'md'
 ]
 
 { #category : 'tests' }

--- a/src/MicroEd/MDFile.class.st
+++ b/src/MicroEd/MDFile.class.st
@@ -84,6 +84,6 @@ MDFile >> save: aString withExtension: anExtension [
 			nextPutAll: aString ].
 	fileReference extension = anExtension asString ifFalse: [ 
 		fileReference renameTo:
-			self basename , '.' , anExtension asString ].
+			self basename , '.' , anExtension asString ]. 
 
 ]

--- a/src/MicroEd/MDFile.class.st
+++ b/src/MicroEd/MDFile.class.st
@@ -84,6 +84,6 @@ MDFile >> save: aString withExtension: anExtension [
 			nextPutAll: aString ].
 	fileReference extension = anExtension asString ifFalse: [ 
 		fileReference renameTo:
-			fileReference withoutExtension basename , '.' , anExtension asString ].
+			self basename , '.' , anExtension asString ].
 
 ]

--- a/src/MicroEd/MDFile.class.st
+++ b/src/MicroEd/MDFile.class.st
@@ -24,7 +24,7 @@ MDFile >> basename [
 	"Answer a String representing the receiver's file name"
 
 	| dateCreationOfFileReference |
-	fileReference ifNil: [ ^ 'Untitled.txt' ].
+	fileReference ifNil: [ ^ 'Untitled.md' ].
 	dateCreationOfFileReference := DateAndTime now asDate yyyymmdd.
 	(fileReference basename includesSubstring:
 		 dateCreationOfFileReference) ifFalse: [
@@ -71,19 +71,36 @@ MDFile >> hasFile [
 
 { #category : 'accessing' }
 MDFile >> initializeWithFileReference: aFileReference [
+	"Add a file reference in the MDFile"
 
+	| newFileReference |
 	aFileReference ensureCreateFile.
-	fileReference := aFileReference
+	fileReference := aFileReference.
+	"Create of a new file reference which has the ISO format with the default extension: 'md' "
+	newFileReference := fileReference extension isEmptyOrNil
+		                    ifTrue: [
+		                    fileReference fileSystem root
+		                    / (self basename , 'md') ]
+		                    ifFalse: [
+		                    fileReference fileSystem root / self basename ].
+	
+	"Then, delete the old file reference to replace with the new file "
+	aFileReference delete.
+
+	newFileReference ensureCreateFile.
+	fileReference := newFileReference
 ]
 
 { #category : 'accessing' }
 MDFile >> save: aString withExtension: anExtension [
-
+" before put the file reference, ensure that the creation of the basename is set (without the renaming)
+fileReference extension = anExtension asString ifFalse: [ 
+		fileReference renameTo:
+			self basename , '.' , anExtension asString ]. "
 	fileReference asFileReference writeStreamDo: [ :str | 
 		str
 			nextPutAll: aString ].
-	fileReference extension = anExtension asString ifFalse: [ 
-		fileReference renameTo:
-			self basename , '.' , anExtension asString ]. 
+	
+		
 
 ]

--- a/src/MicroEd/MDFile.class.st
+++ b/src/MicroEd/MDFile.class.st
@@ -79,16 +79,13 @@ MDFile >> initializeWithFileReference: aFileReference [
 	"Create of a new file reference which has the ISO format with the default extension: 'md' "
 	newFileReference := fileReference extension isEmptyOrNil
 		                    ifTrue: [
-		                    fileReference fileSystem root
-		                    / (self basename , 'md') ]
+		                    (self basename , '.md') ]
 		                    ifFalse: [
-		                    fileReference fileSystem root / self basename ].
-	
-	"Then, delete the old file reference to replace with the new file "
+		                    self basename ].
 	aFileReference delete.
 
-	newFileReference ensureCreateFile.
-	fileReference := newFileReference
+	fileReference := newFileReference asFileReference. 
+	fileReference ensureCreateFile. 
 ]
 
 { #category : 'accessing' }

--- a/src/MicroEd/MDFile.class.st
+++ b/src/MicroEd/MDFile.class.st
@@ -64,6 +64,12 @@ MDFile >> extension: anExtension [
 ]
 
 { #category : 'accessing' }
+MDFile >> fileReference [ 
+
+	^ fileReference 
+]
+
+{ #category : 'accessing' }
 MDFile >> hasFile [ 
 
 	^ fileReference isNotNil 


### PR DESCRIPTION
Correct the method "MDFile>>save: withExtension:" to have the ISO format of the fileReference's  name. 
example:  you can add a note named : 'newNote' and when you add its contents, the name of the file that represents the note changed to :  '2024-07-22newNote.md' . 