### PR TITLE
Load Extensions group from Microdown to use MicTextualMicrodownExporter

### DIFF
--- a/src/BaselineOfMicroEd/BaselineOfMicroEd.class.st
+++ b/src/BaselineOfMicroEd/BaselineOfMicroEd.class.st
@@ -10,13 +10,14 @@ BaselineOfMicroEd >> baseline: spec [
 	<baseline>
 
 	spec for: #'common' do: [
-		"Suppose that this is only for P9
-			spec baseline: ''Microdown'' with: [
-			spec repository: ''github://pillar-markup/Microdown/src'' ]"
+		"We need the Extensions group from Microdown to use MicTextualMicrodownExporter"
+		spec baseline: 'Microdown' with: [
+			spec repository: 'github://pillar-markup/Microdown/src' ].
 		spec 
-			package: 'MicroEd';
+			package: 'MicroEd' with: [ spec 
+				loads: 'Extensions'; 
+				requires: #('Microdown') ];
 			package: 'MicroEd-Spec'  with: [ spec requires: #('MicroEd') ];
 			package: 'MicroEd-Tests' with: [ spec requires: #('MicroEd') ];
-			package: 'MicroEd-Spec-Tests' with: [ spec requires: #('MicroEd') ]
-	]
+			package: 'MicroEd-Spec-Tests' with: [ spec requires: #('MicroEd') ] ]
 ]


### PR DESCRIPTION
This is to avoid the following error:

<img width="384" alt="Screenshot 2024-11-13 at 14 59 28" src="https://github.com/user-attachments/assets/6c5b946f-02ec-4b07-ba8e-abd05be35cfb">
